### PR TITLE
test: verify we don't escape unnecessarily

### DIFF
--- a/test/ESCAPING.md
+++ b/test/ESCAPING.md
@@ -1,0 +1,10 @@
+# Escape test
+
+We want to ensure that SPECIAL_WORDS and https://some_links are not escaped unnecessarily.
+
+Also
+
+* [ ] This
+* [ ] Tasklist
+
+#some-link


### PR DESCRIPTION
### Proposed Changes

Verify escaping and no untracked changes.

Background: I'd love to see this preset to relax some built-in escapings, i.e. around `UNDER_SCORE` names. It otherwise causes verbose markup, unnecessarily.

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->


----


Related to https://github.com/syntax-tree/mdast-util-to-markdown/issues/31, and other issues. I believe remark is simply overly strict with escaping `_` inside of words, a behavior not covered by the [CommonMark](https://spec.commonmark.org/0.31.2/spec.json) specification.